### PR TITLE
Minor Markdown syntax fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # How to convert a ArduinoIDE project to PlatformIO
 
 1) You have to clone the repo to your computer.
-2) In a terminal window you ‘cd’ to the folder where you cloned the repo.
-3) Then you type “python3 arduinoIDE2platformIO.py –project_dir &lt;pathToArduinoProject&gt;<br>
-(there are two ‘-‘ before ‘project_dir’)
+2) In a terminal window you `cd` to the folder where you cloned the repo.
+3) Then you type `python3 arduinoIDE2platformIO.py --project_dir <pathToArduinoProject>`
+(note, there are two `--` before `project_dir`)
 
-The converted project is located in &lt;pathToArduinoProject&gt;/platformIO/
+The converted project is located in `<pathToArduinoProject>/platformIO/`
 
-All you have to do is edit the ‘platformio.ini’ file to your needs.
+All you have to do is edit the `platformio.ini` file to your needs.
 
 Mind you: the convertor will not always do everything for you. Sometimes you have to iterate [compile] -> solve compile errors -> [compile] -> solve compile errors ...
 


### PR DESCRIPTION
Used backticks so the GitHub parser wouldn't convert two consecutive dashes into an em dash, ruining the syntax of the command